### PR TITLE
Increase level range to 999 (9.99)

### DIFF
--- a/DTXCreator/Code/00.App/CDTXInputOutput.cs
+++ b/DTXCreator/Code/00.App/CDTXInputOutput.cs
@@ -45,6 +45,15 @@ namespace DTXCreator
 		}
 		public void tDTX入力( E種別 e種別, ref string str全入力文字列 )
 		{
+			this._Form.hScrollBarDLEVEL.Value = 0;
+			this._Form.textBoxDLEVEL.Text = "0";
+
+			this._Form.hScrollBarGLEVEL.Value = 0;
+			this._Form.textBoxGLEVEL.Text = "0";
+
+			this._Form.hScrollBarBLEVEL.Value = 0;
+			this._Form.textBoxBLEVEL.Text = "0";
+
 			this.e種別 = e種別;
 			if( str全入力文字列.Length != 0 )
 			{

--- a/DTXCreator/Code/00.App/CMainForm.Designer.cs
+++ b/DTXCreator/Code/00.App/CMainForm.Designer.cs
@@ -423,7 +423,7 @@
 			// hScrollBarBLEVEL
 			// 
 			resources.ApplyResources( this.hScrollBarBLEVEL, "hScrollBarBLEVEL" );
-			this.hScrollBarBLEVEL.Maximum = 109;
+			this.hScrollBarBLEVEL.Maximum = 999 + 9;
 			this.hScrollBarBLEVEL.Name = "hScrollBarBLEVEL";
 			this.toolTipツールチップ.SetToolTip( this.hScrollBarBLEVEL, resources.GetString( "hScrollBarBLEVEL.ToolTip" ) );
 			this.hScrollBarBLEVEL.ValueChanged += new System.EventHandler( this.hScrollBarBLEVEL_ValueChanged );
@@ -445,7 +445,7 @@
 			// hScrollBarGLEVEL
 			// 
 			resources.ApplyResources( this.hScrollBarGLEVEL, "hScrollBarGLEVEL" );
-			this.hScrollBarGLEVEL.Maximum = 109;
+			this.hScrollBarGLEVEL.Maximum = 999 + 9;
 			this.hScrollBarGLEVEL.Name = "hScrollBarGLEVEL";
 			this.toolTipツールチップ.SetToolTip( this.hScrollBarGLEVEL, resources.GetString( "hScrollBarGLEVEL.ToolTip" ) );
 			this.hScrollBarGLEVEL.ValueChanged += new System.EventHandler( this.hScrollBarGLEVEL_ValueChanged );
@@ -467,7 +467,7 @@
 			// hScrollBarDLEVEL
 			// 
 			resources.ApplyResources( this.hScrollBarDLEVEL, "hScrollBarDLEVEL" );
-			this.hScrollBarDLEVEL.Maximum = 109;
+			this.hScrollBarDLEVEL.Maximum = 999 + 9;
 			this.hScrollBarDLEVEL.Name = "hScrollBarDLEVEL";
 			this.toolTipツールチップ.SetToolTip( this.hScrollBarDLEVEL, resources.GetString( "hScrollBarDLEVEL.ToolTip" ) );
 			this.hScrollBarDLEVEL.ValueChanged += new System.EventHandler( this.hScrollBarDLEVEL_ValueChanged );


### PR DESCRIPTION
- Drum level is being defaulted to 50 (https://github.com/limyz/DTXmaniaNX/blob/master/DTXCreatorProject/Code/00.App/CMainForm.cs#L523,L526), but the value will not be cleared/set to 0 if you load a DTX file without a drum chart. So make sure *all* difficulty levels are set to 0 when loading a new DTX file.

- Increase the range from 0 - 100 to 0 - 999 (9.99) to make it possible to load charts with Gitadora-style levels without crashing.