### PR TITLE
Move best score inside small graph

### DIFF
--- a/DTXMania/Code/Stage/07.Performance/CActPerfSkillMeter.cs
+++ b/DTXMania/Code/Stage/07.Performance/CActPerfSkillMeter.cs
@@ -199,9 +199,16 @@ namespace DTXMania
                     {
                         this.txグラフ.tDraw2D(CDTXMania.app.Device, nGraphBG_XPos[this.nGraphUsePart], nGraphBG_YPos, new Rectangle(2, 2, 251, 584));
                     }
-                    
+
                     //自己ベスト数値表示
-                    this.t達成率文字表示( nGraphBG_XPos[ this.nGraphUsePart ] + 136, nGraphBG_YPos + 501, string.Format( "{0,6:##0.00}" + "%", this.dbGraphValue_PersonalBest ) );
+                    if (CDTXMania.ConfigIni.bSmallGraph)
+                    {
+                        this.t達成率文字表示( nGraphBG_XPos[ this.nGraphUsePart ] - 3, nGraphBG_YPos + 531, string.Format( "{0,6:##0.00}" + "%", this.dbGraphValue_PersonalBest ) );
+                    }
+                    else
+                    {
+                        this.t達成率文字表示(nGraphBG_XPos[this.nGraphUsePart] + 136, nGraphBG_YPos + 501, string.Format("{0,6:##0.00}" + "%", this.dbGraphValue_PersonalBest));
+                    }
                 }
 
                 //ゲージ現在


### PR DESCRIPTION
When small graph was used, best score was outside the graph panel. Moved it inside the panel under the legend.

Before:
![image](https://user-images.githubusercontent.com/288517/97578358-c929f300-1a44-11eb-891a-cedb1cc4fbf0.png)

After:
![image](https://user-images.githubusercontent.com/288517/97578410-d8a93c00-1a44-11eb-8403-d00beaa0c9a7.png)

