### PR TITLE
Fix #103 Cap play speed between x0.25 and x2 during game

### DIFF
--- a/DTXMania/Code/App/CConfigIni.cs
+++ b/DTXMania/Code/App/CConfigIni.cs
@@ -3105,7 +3105,7 @@ namespace DTXMania
 											}
 											else if( str3.Equals( "PlaySpeed" ) )
 											{
-												this.nPlaySpeed = CConversion.nGetNumberIfInRange( str4, 5, 40, this.nPlaySpeed );
+												this.nPlaySpeed = CConversion.nGetNumberIfInRange( str4, CConstants.PLAYSPEED_MIN, CConstants.PLAYSPEED_MAX, this.nPlaySpeed );
 											}
 											else if (str3.Equals("SaveScoreIfModifiedPlaySpeed"))
 											{

--- a/DTXMania/Code/App/CConstants.cs
+++ b/DTXMania/Code/App/CConstants.cs
@@ -785,6 +785,8 @@ namespace DTXMania
 		public const int SCORE_H = 0x18;
 		public const int SCORE_W = 12;
 		public const int SUDDEN_POS = 200;
+		public const int PLAYSPEED_MIN = 5;
+		public const int PLAYSPEED_MAX = 40;
 
 		public class Drums
 		{

--- a/DTXMania/Code/Stage/04.Config/CActConfigList.cs
+++ b/DTXMania/Code/Stage/04.Config/CActConfigList.cs
@@ -115,7 +115,7 @@ namespace DTXMania
                 new string[] { "0%", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%", "100%" });
             this.listItems.Add(this.iSystemMovieAlpha);
 
-            this.iCommonPlaySpeed = new CItemInteger("PlaySpeed", 5, 40, CDTXMania.ConfigIni.nPlaySpeed,
+            this.iCommonPlaySpeed = new CItemInteger("PlaySpeed", CConstants.PLAYSPEED_MIN, CConstants.PLAYSPEED_MAX, CDTXMania.ConfigIni.nPlaySpeed,
                 "曲の演奏速度を、速くしたり\n"+
                 "遅くしたりすることができます。\n"+
                 "※一部のサウンドカードでは、\n"+

--- a/DTXMania/Code/Stage/05.SongSelection/CActSelectQuickConfig.cs
+++ b/DTXMania/Code/Stage/05.SongSelection/CActSelectQuickConfig.cs
@@ -99,7 +99,7 @@ namespace DTXMania
                 " the number of Poor/Miss times to be\n" +
                 " FAILED.\n" +
                 "Set 0 to disable Risky mode."));
-            l.Add(new CItemInteger("PlaySpeed", 5, 40, CDTXMania.ConfigIni.nPlaySpeed,
+            l.Add(new CItemInteger("PlaySpeed", CConstants.PLAYSPEED_MIN, CConstants.PLAYSPEED_MAX, CDTXMania.ConfigIni.nPlaySpeed,
                 "曲の演奏速度を、速くしたり遅くした\n" +
                 "りすることができます。\n" +
                 "（※一部のサウンドカードでは正しく\n" +

--- a/DTXMania/Code/Stage/07.Performance/CStagePerfCommonScreen.cs
+++ b/DTXMania/Code/Stage/07.Performance/CStagePerfCommonScreen.cs
@@ -2075,14 +2075,20 @@ namespace DTXMania
                 else if (CDTXMania.Pad.bPressed(EKeyConfigPart.SYSTEM, EKeyConfigPad.DecreasePlaySpeed))
                 {
                     // Decrease Play Speed
-                    this.bIsTrainingMode = true;
-                    this.tChangePlaySpeed(-1);
+                    if (CDTXMania.ConfigIni.nPlaySpeed > CConstants.PLAYSPEED_MIN)
+                    {
+                        this.bIsTrainingMode = true;
+                        this.tChangePlaySpeed(-1);
+                    }
                 }
                 else if (CDTXMania.Pad.bPressed(EKeyConfigPart.SYSTEM, EKeyConfigPad.IncreasePlaySpeed))
                 {
                     // Increase Play Speed
-                    this.bIsTrainingMode = true;
-                    this.tChangePlaySpeed(1);
+                    if (CDTXMania.ConfigIni.nPlaySpeed < CConstants.PLAYSPEED_MAX)
+                    {
+                        this.bIsTrainingMode = true;
+                        this.tChangePlaySpeed(1);
+                    }
                 }
 
                 if (!CDTXMania.ConfigIni.bReverse.Drums && keyboard.bKeyPressing((int)SlimDXKey.PageUp))


### PR DESCRIPTION
Furukon reported that play speed could be decreased to 0, actually freezing the game, or higher than x2.
I'm restricting play speed to be between x0.25 and x2 (5 and 40) during the game.