### PR TITLE
Fix #106 DTXManiaGR crashes in viewer mode launched by DTXCreator

### DIFF
--- a/DTXMania/Code/App/CDTXMania.cs
+++ b/DTXMania/Code/App/CDTXMania.cs
@@ -2476,7 +2476,7 @@ for (int i = 0; i < 3; i++) {
             #endregion
 
             #region [ Discord Rich Presence ]
-            if (ConfigIni.bDiscordRichPresenceEnabled)
+            if (ConfigIni.bDiscordRichPresenceEnabled && !bCompactMode)
                 DiscordRichPresence = new CDiscordRichPresence(ConfigIni.strDiscordRichPresenceApplicationID);
             #endregion
 

--- a/DTXMania/Code/Stage/07.Performance/CStagePerfCommonScreen.cs
+++ b/DTXMania/Code/Stage/07.Performance/CStagePerfCommonScreen.cs
@@ -33,7 +33,7 @@ namespace DTXMania
                 // if presence is displayed before this point then it will use
                 // the unitialised timer time, displaying an incorrect timestamp
                 // so dont display any presence until initialisation has occurred
-                if (bJustStartedUpdate)
+                if (bJustStartedUpdate || CDTXMania.bCompactMode)
                     return null;
 
                 var stSongInformation = CDTXMania.stageSongSelection.rSelectedScore.SongInformation;

--- a/DTXMania/Code/Stage/07.Performance/DrumsScreen/CStagePerfDrumsScreen.cs
+++ b/DTXMania/Code/Stage/07.Performance/DrumsScreen/CStagePerfDrumsScreen.cs
@@ -305,7 +305,16 @@ namespace DTXMania
                 bIsFinishedFadeout = this.tUpdateAndDraw_FadeIn_Out();
                 if (bIsFinishedPlaying && (base.ePhaseID == CStage.EPhase.Common_DefaultState) )
                 {
-                    if ((this.actGauge.IsFailed(EInstrumentPart.DRUMS)) && (base.ePhaseID == CStage.EPhase.Common_DefaultState))
+                    if (CDTXMania.DTXVmode.Enabled)
+                    {
+                        if (CDTXMania.Timer.b停止していない)
+                        {
+                            CDTXMania.Timer.tPause();
+                        }
+                        Thread.Sleep(5);
+                        // Keep waiting for next message from DTX Creator
+                    }
+                    else if ((this.actGauge.IsFailed(EInstrumentPart.DRUMS)) && (base.ePhaseID == CStage.EPhase.Common_DefaultState))
                     {
                         this.actStageFailed.Start();
                         CDTXMania.DTX.tStopPlayingAllChips();


### PR DESCRIPTION
Fixed 2 crashes when DTXMania is used as viewer by DTXCreator:
- one crash caused by Discord Presence not being able to read the song name => disable Discord Presence in viewer mode
- one crash caused by Result screen not able to read song name => don't display result screen, stay on song screen waiting new input from Creator