### PR TITLE
Fix null reference exception when CLASSIC=1

### DIFF
--- a/DTXMania/Code/Stage/05.SongSelection/CActSelectStatusPanel.cs
+++ b/DTXMania/Code/Stage/05.SongSelection/CActSelectStatusPanel.cs
@@ -317,14 +317,14 @@ namespace DTXMania
                                     // convert the level back into a whole number (0-999) to make it easier to work with
                                     int nLevel = (n現在選択中の曲のレベル難易度毎DGB[i][j] * 10) + n現在選択中の曲のレベル小数点難易度毎DGB[i][j];
                                     bool bHasSong = b現在選択中の曲に譜面がある[i][j];
-                                    bool bShowClassicLevel = CDTXMania.ConfigIni.nSkillMode == 0 ||
+                                    bool bShowClassicLevel = CDTXMania.ConfigIni.nSkillMode == 0;
                                                              (CDTXMania.ConfigIni.bCLASSIC譜面判別を有効にする &&
-                                                             !CDTXMania.DTX.bチップがある.LeftCymbal &&
-                                                             !CDTXMania.DTX.bチップがある.LP &&
-                                                             !CDTXMania.DTX.bチップがある.LBD &&
-                                                             !CDTXMania.DTX.bチップがある.FT &&
-                                                             !CDTXMania.DTX.bチップがある.Ride &&
-                                                             !CDTXMania.DTX.b強制的にXG譜面にする);
+                                                             !(CDTXMania?.DTX?.bチップがある?.LeftCymbal ?? true) &&
+                                                             !(CDTXMania?.DTX?.bチップがある?.LP ?? true) &&
+                                                             !(CDTXMania?.DTX?.bチップがある?.LBD ?? true) &&
+                                                             !(CDTXMania?.DTX?.bチップがある?.FT ?? true) &&
+                                                             !(CDTXMania?.DTX?.bチップがある?.Ride ?? true) &&
+                                                             !(CDTXMania?.DTX?.b強制的にXG譜面にする ?? true));
 
                                     int nX = nBoxX + nPanelW - 77;
                                     int nY = nBoxY + nPanelH - 35;

--- a/DTXMania/Code/Stage/05.SongSelection/CActSelectStatusPanel.cs
+++ b/DTXMania/Code/Stage/05.SongSelection/CActSelectStatusPanel.cs
@@ -317,7 +317,7 @@ namespace DTXMania
                                     // convert the level back into a whole number (0-999) to make it easier to work with
                                     int nLevel = (n現在選択中の曲のレベル難易度毎DGB[i][j] * 10) + n現在選択中の曲のレベル小数点難易度毎DGB[i][j];
                                     bool bHasSong = b現在選択中の曲に譜面がある[i][j];
-                                    bool bShowClassicLevel = CDTXMania.ConfigIni.nSkillMode == 0;
+                                    bool bShowClassicLevel = CDTXMania.ConfigIni.nSkillMode == 0 ||
                                                              (CDTXMania.ConfigIni.bCLASSIC譜面判別を有効にする &&
                                                              !(CDTXMania?.DTX?.bチップがある?.LeftCymbal ?? true) &&
                                                              !(CDTXMania?.DTX?.bチップがある?.LP ?? true) &&


### PR DESCRIPTION
This pull request changes the bShowClassicLevel check to be null reference resistant as CDTXMania.DTX is not always a non-null value.

This fixes issue #108.