### PR TITLE
Display exception messages when search songs

### DIFF
--- a/DTXMania/Code/Score,Song/CSongManager.cs
+++ b/DTXMania/Code/Score,Song/CSongManager.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Drawing;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace DTXMania
 {
@@ -136,7 +137,15 @@ namespace DTXMania
 		//-----------------
 		public void tSearchSongsAndCreateList( string str基点フォルダ, bool b子BOXへ再帰する )
 		{
-			this.tSearchSongsAndCreateList( str基点フォルダ, b子BOXへ再帰する, this.listSongRoot, null );
+			try
+			{
+				this.tSearchSongsAndCreateList(str基点フォルダ, b子BOXへ再帰する, this.listSongRoot, null);
+			}
+			catch (Exception e)
+			{
+				Trace.TraceError(e.Message);
+				MessageBox.Show(e.Message, "Exception occurs when search songs", MessageBoxButtons.OK, MessageBoxIcon.Hand, MessageBoxDefaultButton.Button1);
+			}
 		}
 		private void tSearchSongsAndCreateList( string str基点フォルダ, bool b子BOXへ再帰する, List<CSongListNode> listノードリスト, CSongListNode node親 )
 		{


### PR DESCRIPTION
This PR aims to solve #190.

While we can add try/catch in every `GetDirectories()` or `GetFiles()` to collect as much valid songs as possible, I decided to simply catch exceptions at the top most entry point. 

Despite we may skip gathering some songs, the approach makes the code easier to maintain.