### PR TITLE
Fix FAST/SLOW result count in twin guitar

### DIFF
--- a/DTXMania/Code/App/CDTXMania.cs
+++ b/DTXMania/Code/App/CDTXMania.cs
@@ -1551,6 +1551,11 @@ for (int i = 0; i < 3; i++) {
                                         cPerfEntry_Guitar = cPerfEntry_Bass;
                                         cPerfEntry_Bass = t;
 
+                                        CStagePerfCommonScreen.CLAGTIMINGHITCOUNT tLagHitCount;
+                                        tLagHitCount = stageResult.nTimingHitCount.Guitar;
+                                        stageResult.nTimingHitCount.Guitar = stageResult.nTimingHitCount.Bass;
+                                        stageResult.nTimingHitCount.Bass = tLagHitCount;
+
                                         CDTXMania.DTX.SwapGuitarBassInfos();			// 譜面情報も元に戻す
                                         CDTXMania.ConfigIni.SwapGuitarBassInfos_AutoFlags(); // #24415 2011.2.27 yyagi
                                         // リザルト集計時のみ、Auto系のフラグも元に戻す。


### PR DESCRIPTION
## Summary

This fixes an issue in Twin Guitar / Dual Guitar result screens where FAST/SLOW counts were displayed on the wrong player panel.

When 1P was played manually and 2P was AUTO, normal judgment counts were shown correctly, but the FAST/SLOW counts from the manual side appeared on the AUTO side.

## Cause

In Twin/Flip guitar mode, Guitar/Bass performance data is swapped during gameplay and restored before the result screen.

The normal result entries were restored correctly, but `stageResult.nTimingHitCount` was not restored in the same block. As a result, FAST/SLOW counts used a different Guitar/Bass mapping than the normal judgment counts.

## Changes

- Restore `nTimingHitCount.Guitar/Bass` together with the normal performance entries
- Align FAST/SLOW result display with the same Guitar/Bass mapping as Perfect/Great/Good/Ok/Miss
- Does not change judgment timing
- Does not change AUTO judgment behavior

## Tested

- Built with x64 Debug:

  `msbuild DTXMania.sln /p:Configuration=Debug /p:Platform=x64`

- Tested Twin Guitar / Dual Guitar locally
- Confirmed that with 1P manual and 2P AUTO:
  - 1P panel shows FAST/SLOW counts
  - 2P AUTO panel remains 0/0
  - Normal judgment counts remain correct