### PR TITLE
Fix realtime graph state in twin guitar

### DIFF
--- a/DTXMania/Code/Stage/07.Performance/CActPerfSkillMeter.cs
+++ b/DTXMania/Code/Stage/07.Performance/CActPerfSkillMeter.cs
@@ -44,11 +44,11 @@ namespace DTXMania
         {
             get
             {
-                return this.dbグラフ値現在;
+                return this.dbグラフ値現在[(int)this.nGraphUsePart];
             }
             set
             {
-                this.dbグラフ値現在 = value;
+                this.SetCurrentGraphValue((EInstrumentPart)this.nGraphUsePart, value);
             }
         }
         public double dbGraphValue_Goal
@@ -81,13 +81,23 @@ namespace DTXMania
 			base.bNotActivated = true;
 		}
 
+        public void SetCurrentGraphValue(EInstrumentPart inst, double value)
+        {
+            if (inst == EInstrumentPart.UNKNOWN)
+            {
+                return;
+            }
+
+            this.dbグラフ値現在[(int)inst] = value;
+        }
+
 
 		// CActivity 実装
 
 		public override void OnActivate()
         {
             this.dbグラフ値目標 = 0f;
-            this.dbグラフ値現在 = 0f;
+            this.dbグラフ値現在 = default(STDGBVALUE<double>);
 
             this.n現在のAutoを含まない判定数 = new int[ 6 ];
 
@@ -214,8 +224,9 @@ namespace DTXMania
                 //ゲージ現在
                 if (this.txグラフ_ゲージ != null)
                 {
+                    double dbCurrentGraphValue = this.dbグラフ値現在[this.nGraphUsePart];
                     //ゲージ本体
-                    int nGaugeSize = (int)(434.0f * (float)this.dbグラフ値現在 / 100.0f);
+                    int nGaugeSize = (int)(434.0f * (float)dbCurrentGraphValue / 100.0f);
                     int nPosY = this.nGraphUsePart == 0 ? 527 - nGaugeSize : 587 - nGaugeSize;
                     if (!this.bIsTrainingMode)
                     {
@@ -225,7 +236,7 @@ namespace DTXMania
                     //ゲージ比較
                     int nTargetGaugeSize = (int)( 434.0f * ( (float)this.dbグラフ値目標 / 100.0f ) );
                     int nTargetGaugePosY = this.nGraphUsePart == 0 ? 527 - nTargetGaugeSize : 587 - nTargetGaugeSize;
-                    int nTargetGaugeRectX = this.dbグラフ値現在 > this.dbグラフ値目標 ? 38 : 74;
+                    int nTargetGaugeRectX = dbCurrentGraphValue > this.dbグラフ値目標 ? 38 : 74;
                     this.txグラフ_ゲージ.nTransparency = 255;
                     this.txグラフ_ゲージ.tDraw2D( CDTXMania.app.Device, nGraphBG_XPos[ this.nGraphUsePart ] + 75 + nGraphSizeOffset, nTargetGaugePosY, new Rectangle( nTargetGaugeRectX, 2, 30, nTargetGaugeSize ) );
                     if( this.txグラフ != null )
@@ -249,7 +260,7 @@ namespace DTXMania
                             this.txグラフ.tDraw2D(CDTXMania.app.Device, nGraphBG_XPos[this.nGraphUsePart] + 164, nGraphBG_YPos + 357, new Rectangle(260 + 120, 2, 30, 120));
                         }
                     }
-                    this.t比較文字表示( nGraphBG_XPos[ this.nGraphUsePart ] + 44 + nGraphSizeOffset, nPosY - 10, string.Format( "{0,5:##0.00}", Math.Abs( this.dbグラフ値現在 ) ) );
+                    this.t比較文字表示( nGraphBG_XPos[ this.nGraphUsePart ] + 44 + nGraphSizeOffset, nPosY - 10, string.Format( "{0,5:##0.00}", Math.Abs( dbCurrentGraphValue ) ) );
                     this.t比較文字表示( nGraphBG_XPos[ this.nGraphUsePart ] + 74 + nGraphSizeOffset, nTargetGaugePosY - 10, string.Format( "{0,5:##0.00}", Math.Abs( this.dbグラフ値目標 ) ) );
                 }
 
@@ -265,7 +276,7 @@ namespace DTXMania
 		//----------------
         private double dbグラフ値目標;
         private double dbグラフ値目標_表示;
-        private double dbグラフ値現在;
+        private STDGBVALUE<double> dbグラフ値現在;
         private double dbグラフ値現在_表示;
         public double dbGraphValue_PersonalBest;
         private int[] n現在のAutoを含まない判定数;

--- a/DTXMania/Code/Stage/07.Performance/GuitarScreen/CStagePerfGuitarScreen.cs
+++ b/DTXMania/Code/Stage/07.Performance/GuitarScreen/CStagePerfGuitarScreen.cs
@@ -351,24 +351,27 @@ namespace DTXMania
 			EJudgement eJudgeResult = tProcessChipHit( nHitTime, pChip, EInstrumentPart.GUITAR, bCorrectLane );
             if(pChip.eInstrumentPart == EInstrumentPart.GUITAR)
 			{
+				double dbGraphValue;
 				if (CDTXMania.ConfigIni.nSkillMode == 0)
-					this.actGraph.dbグラフ値現在_渡 = CScoreIni.tCalculatePlayingSkillOld(CDTXMania.DTX.nVisibleChipsCount.Guitar, this.nHitCount_ExclAuto.Guitar.Perfect, this.nHitCount_ExclAuto.Guitar.Great, this.nHitCount_ExclAuto.Guitar.Good, this.nHitCount_ExclAuto.Guitar.Poor, this.nHitCount_ExclAuto.Guitar.Miss, this.actCombo.nCurrentCombo.HighestValue.Guitar, EInstrumentPart.GUITAR, bIsAutoPlay);
+					dbGraphValue = CScoreIni.tCalculatePlayingSkillOld(CDTXMania.DTX.nVisibleChipsCount.Guitar, this.nHitCount_ExclAuto.Guitar.Perfect, this.nHitCount_ExclAuto.Guitar.Great, this.nHitCount_ExclAuto.Guitar.Good, this.nHitCount_ExclAuto.Guitar.Poor, this.nHitCount_ExclAuto.Guitar.Miss, this.actCombo.nCurrentCombo.HighestValue.Guitar, EInstrumentPart.GUITAR, bIsAutoPlay);
 				else
-					this.actGraph.dbグラフ値現在_渡 = CScoreIni.tCalculatePlayingSkill(CDTXMania.DTX.nVisibleChipsCount.Guitar, this.nHitCount_ExclAuto.Guitar.Perfect, this.nHitCount_ExclAuto.Guitar.Great, this.nHitCount_ExclAuto.Guitar.Good, this.nHitCount_ExclAuto.Guitar.Poor, this.nHitCount_ExclAuto.Guitar.Miss, this.actCombo.nCurrentCombo.HighestValue.Guitar, EInstrumentPart.GUITAR, bIsAutoPlay);
-				this.actStatusPanel.db現在の達成率.Guitar = this.actGraph.dbグラフ値現在_渡;
+					dbGraphValue = CScoreIni.tCalculatePlayingSkill(CDTXMania.DTX.nVisibleChipsCount.Guitar, this.nHitCount_ExclAuto.Guitar.Perfect, this.nHitCount_ExclAuto.Guitar.Great, this.nHitCount_ExclAuto.Guitar.Good, this.nHitCount_ExclAuto.Guitar.Poor, this.nHitCount_ExclAuto.Guitar.Miss, this.actCombo.nCurrentCombo.HighestValue.Guitar, EInstrumentPart.GUITAR, bIsAutoPlay);
+				this.actStatusPanel.db現在の達成率.Guitar = dbGraphValue;
 
 				if (CDTXMania.ConfigIni.bGraph有効.Guitar)
 				{
+					this.actGraph.SetCurrentGraphValue(EInstrumentPart.GUITAR, dbGraphValue);
 
 					if (CDTXMania.listTargetGhsotLag.Guitar != null &&
 						CDTXMania.ConfigIni.eTargetGhost.Guitar == ETargetGhostData.ONLINE &&
 						CDTXMania.DTX.nVisibleChipsCount.Guitar > 0)
 					{
 
-						this.actGraph.dbグラフ値現在_渡 = 100 *
+						dbGraphValue = 100 *
 										(this.nHitCount_ExclAuto.Guitar.Perfect * 17 +
 										 this.nHitCount_ExclAuto.Guitar.Great * 7 +
 										 this.actCombo.nCurrentCombo.HighestValue.Guitar * 3) / (20.0 * CDTXMania.DTX.nVisibleChipsCount.Guitar);
+						this.actGraph.SetCurrentGraphValue(EInstrumentPart.GUITAR, dbGraphValue);
 					}
 
 					this.actGraph.n現在のAutoを含まない判定数_渡[0] = this.nHitCount_ExclAuto.Guitar.Perfect;
@@ -380,24 +383,27 @@ namespace DTXMania
 			}
 			else if(pChip.eInstrumentPart == EInstrumentPart.BASS)
 			{
+				double dbGraphValue;
 				if (CDTXMania.ConfigIni.nSkillMode == 0)
-					this.actGraph.dbグラフ値現在_渡 = CScoreIni.tCalculatePlayingSkillOld(CDTXMania.DTX.nVisibleChipsCount.Bass, this.nHitCount_ExclAuto.Bass.Perfect, this.nHitCount_ExclAuto.Bass.Great, this.nHitCount_ExclAuto.Bass.Good, this.nHitCount_ExclAuto.Bass.Poor, this.nHitCount_ExclAuto.Bass.Miss, this.actCombo.nCurrentCombo.HighestValue.Bass, EInstrumentPart.BASS, bIsAutoPlay);
+					dbGraphValue = CScoreIni.tCalculatePlayingSkillOld(CDTXMania.DTX.nVisibleChipsCount.Bass, this.nHitCount_ExclAuto.Bass.Perfect, this.nHitCount_ExclAuto.Bass.Great, this.nHitCount_ExclAuto.Bass.Good, this.nHitCount_ExclAuto.Bass.Poor, this.nHitCount_ExclAuto.Bass.Miss, this.actCombo.nCurrentCombo.HighestValue.Bass, EInstrumentPart.BASS, bIsAutoPlay);
 				else
-					this.actGraph.dbグラフ値現在_渡 = CScoreIni.tCalculatePlayingSkill(CDTXMania.DTX.nVisibleChipsCount.Bass, this.nHitCount_ExclAuto.Bass.Perfect, this.nHitCount_ExclAuto.Bass.Great, this.nHitCount_ExclAuto.Bass.Good, this.nHitCount_ExclAuto.Bass.Poor, this.nHitCount_ExclAuto.Bass.Miss, this.actCombo.nCurrentCombo.HighestValue.Bass, EInstrumentPart.BASS, bIsAutoPlay);
-				this.actStatusPanel.db現在の達成率.Bass = this.actGraph.dbグラフ値現在_渡;
+					dbGraphValue = CScoreIni.tCalculatePlayingSkill(CDTXMania.DTX.nVisibleChipsCount.Bass, this.nHitCount_ExclAuto.Bass.Perfect, this.nHitCount_ExclAuto.Bass.Great, this.nHitCount_ExclAuto.Bass.Good, this.nHitCount_ExclAuto.Bass.Poor, this.nHitCount_ExclAuto.Bass.Miss, this.actCombo.nCurrentCombo.HighestValue.Bass, EInstrumentPart.BASS, bIsAutoPlay);
+				this.actStatusPanel.db現在の達成率.Bass = dbGraphValue;
 
 				if (CDTXMania.ConfigIni.bGraph有効.Bass)
 				{
+					this.actGraph.SetCurrentGraphValue(EInstrumentPart.BASS, dbGraphValue);
 
 					if (CDTXMania.listTargetGhsotLag.Bass != null &&
 						CDTXMania.ConfigIni.eTargetGhost.Bass == ETargetGhostData.ONLINE &&
 						CDTXMania.DTX.nVisibleChipsCount.Bass > 0)
 					{
 
-						this.actGraph.dbグラフ値現在_渡 = 100 *
+						dbGraphValue = 100 *
 										(this.nHitCount_ExclAuto.Bass.Perfect * 17 +
 										 this.nHitCount_ExclAuto.Bass.Great * 7 +
 										 this.actCombo.nCurrentCombo.HighestValue.Bass * 3) / (20.0 * CDTXMania.DTX.nVisibleChipsCount.Bass);
+						this.actGraph.SetCurrentGraphValue(EInstrumentPart.BASS, dbGraphValue);
 					}
 
 					this.actGraph.n現在のAutoを含まない判定数_渡[0] = this.nHitCount_ExclAuto.Bass.Perfect;


### PR DESCRIPTION
## Summary

This fixes an issue in Twin Guitar / Dual Guitar gameplay where the realtime skill graph briefly updated after a manual hit, but immediately returned to 0.

This happened when 1P was played manually and 2P was AUTO.

## Cause

`CActPerfSkillMeter` stored the current graph value as a single shared `double`.

In Twin Guitar mode, Guitar and Bass processing shared the same `actGraph` instance. As a result, the AUTO side or non-displayed side could overwrite the manual side's current graph value with a 0-like value.

## Changes

- Store current graph values separately for Drums / Guitar / Bass
- Add a method to set the current graph value for a specific instrument part
- Use the current graph value for the displayed instrument part when drawing
- Prevent the AUTO side from overwriting the manual side's realtime graph state
- Does not change judgment timing
- Does not change result calculation

## Tested

- Built with x64 Debug:

  `msbuild DTXMania.sln /p:Configuration=Debug /p:Platform=x64`

- Tested Twin Guitar / Dual Guitar locally
- Confirmed that with 1P manual and 2P AUTO:
  - 1P realtime graph updates and stays visible
  - 1P graph no longer returns to 0 after each hit
  - 2P AUTO side does not overwrite 1P graph state
- Confirmed Guitar single play still works normally