### PR TITLE
Fix inverted AVI window playback in Guitar/Bass

### DIFF
--- a/DTXMania/Code/Stage/07.Performance/CActPerfAVI.cs
+++ b/DTXMania/Code/Stage/07.Performance/CActPerfAVI.cs
@@ -772,9 +772,9 @@ namespace DTXMania
                             if( this.rAVI != null )
                             {
                                 if( this.fClipアスペクト比 < 1.77f )
-                                    this.tx描画用.tDraw2D( CDTXMania.app.Device, this.position2, 5 + this.n本体Y );
+                                    this.tx描画用.tDraw2DUpsideDown( CDTXMania.app.Device, this.position2, 5 + this.n本体Y );
                                 else
-                                    this.tx描画用.tDraw2D( CDTXMania.app.Device, 30 + this.n本体X, this.position2 );
+                                    this.tx描画用.tDraw2DUpsideDown( CDTXMania.app.Device, 30 + this.n本体X, this.position2 );
                             }
                         }
                         #endregion


### PR DESCRIPTION
## Summary

Fixes an issue where the AVI/movie displayed in the Guitar/Bass movie window was vertically inverted.

The fullscreen background movie and Drums movie window were displayed correctly, but the Guitar/Bass movie window was upside down.

## Cause

The Guitar/Bass movie window drawing path used `tDraw2D()`, while the Drums movie window and fullscreen background movie paths already used `tDraw2DUpsideDown()`.

As a result, only the Guitar/Bass movie window was displayed vertically flipped.

## Changes

Changed the Guitar/Bass movie window drawing calls in `CActPerfAVI.cs` from `tDraw2D()` to `tDraw2DUpsideDown()`.

## Testing

Built successfully with:

```powershell
msbuild DTXMania.sln /p:Configuration=Debug /p:Platform=x64